### PR TITLE
Refactor Assistant and Introduce Jarbles Structs

### DIFF
--- a/jarbles.go
+++ b/jarbles.go
@@ -1,0 +1,42 @@
+package jarbles_framework
+
+type functionProperty struct {
+	Type        string   `json:"type"`
+	Description string   `json:"description"`
+	Enum        []string `json:"enum"`
+}
+
+type functionParameters struct {
+	Type       string                      `json:"type,omitempty"`
+	Required   []string                    `json:"required,omitempty"`
+	Properties map[string]functionProperty `json:"properties,omitempty"`
+}
+
+type toolFunction struct {
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Parameters  *functionParameters `json:"parameters,omitempty"`
+}
+
+type tool struct {
+	Type     string        `json:"type"`
+	Function *toolFunction `json:"function"`
+}
+
+type quicklink struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+type frameworkAssistant struct {
+	StaticID     string      `json:"static_id"`
+	Name         string      `json:"name"`
+	Description  string      `json:"description"`
+	Model        string      `json:"model"`
+	Instructions string      `json:"instructions"`
+	Tools        []tool      `json:"tools,omitempty"`
+	Version      string      `json:"version,omitempty"`
+	BinaryName   string      `json:"binary_name,omitempty"`
+	Placeholder  string      `json:"placeholder,omitempty"`
+	Quicklinks   []quicklink `json:"quicklinks,omitempty"`
+}


### PR DESCRIPTION
- assistant.go: Remove base64 encoding for avatar, refactor to `frameworkAssistant`, add `AddInstructions`, update `AddAction`
- jarbles.go: Define structs for framework, tool, quicklink, assistant